### PR TITLE
fix: phase 1 prompt integrity and workflow hardening

### DIFF
--- a/.github/workflows/validate-registry.yml
+++ b/.github/workflows/validate-registry.yml
@@ -1,9 +1,20 @@
 name: Validate Registry on PR
 
-# This workflow validates the registry.json and prompt library structure on all PRs.
-# 
-# For bot-created PRs (like automated version bumps), the workflow won't trigger automatically
-# due to GitHub's security restrictions. In those cases, you can manually trigger this workflow:
+# SECURITY HARDENING (Issue #6):
+# This workflow uses the secure pull_request + workflow_dispatch pattern to prevent
+# untrusted PR code execution with elevated permissions.
+#
+# SECURITY RATIONALE:
+# - pull_request_target runs in base branch context with write permissions
+# - Checking out PR head code in that context allows malicious PRs to exfiltrate secrets
+# - Solution: Use pull_request (isolated PR context) + workflow_dispatch for manual bot PR handling
+#
+# TRADEOFFS:
+# - Auto-commit to PR branch disabled for security (pull_request has no write access to PR branch)
+# - Fork PRs: Validation runs, but registry updates must be done manually by contributor
+# - Bot PRs: Manual trigger via workflow_dispatch preserves functionality
+#
+# For bot-created PRs or when auto-commit is needed, use manual trigger:
 #
 # Option 1 - Run Validation:
 # 1. Go to Actions > Validate Registry on PR > Run workflow
@@ -19,14 +30,16 @@ name: Validate Registry on PR
 # 5. The check will pass immediately without running validation
 
 on:
-  # Use pull_request_target to allow running on bot-created PRs
-  # This also allows the workflow to write to the PR branch
-  pull_request_target:
+  # SECURE: pull_request runs in PR context (isolated from base branch)
+  # No write access to base branch, preventing secret exfiltration
+  # Reference: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request:
     branches:
       - main
       - dev
-    # Removed paths filter - this check is required by repository ruleset
-    # so it must run on ALL PRs to prevent blocking merges
+    # No paths filter - required by repository ruleset to run on ALL PRs
+  
+  # Manual trigger for bot PRs or when write access is needed
   workflow_dispatch:
     inputs:
       pr_number:
@@ -38,9 +51,17 @@ on:
         required: false
         type: boolean
         default: false
+      enable_auto_commit:
+        description: 'Enable auto-commit of registry updates (trusted PRs only)'
+        required: false
+        type: boolean
+        default: false
 
+# LEAST PRIVILEGE: Minimal permissions for validation
+# contents: read - checkout repository
+# pull-requests: write - post comments on fork PRs
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
@@ -58,15 +79,29 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The workflow will complete successfully without running validation steps." >> $GITHUB_STEP_SUMMARY
       
-      - name: Checkout repository (for manual runs)
+      # SECURE CHECKOUT PATTERN (Issue #6):
+      # For pull_request events: checkout base branch only (safe, no PR code)
+      # For workflow_dispatch: can optionally checkout PR branch with explicit trust
+      - name: Checkout repository
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.skip_validation != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Get PR details (for manual runs)
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '' && github.event.inputs.skip_validation != 'true'
+      # For automatic PR runs: checkout base branch only (SECURE - no PR code execution)
+      - name: Checkout repository (automatic PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.base_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      # For manual runs with auto-commit enabled: fetch PR details and checkout PR branch
+      # This is SAFE because maintainer explicitly triggered it (trusted)
+      - name: Get PR details (for manual runs with auto-commit)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '' && github.event.inputs.skip_validation != 'true' && github.event.inputs.enable_auto_commit == 'true'
         id: get_pr
         run: |
           PR_DATA=$(gh pr view ${{ github.event.inputs.pr_number }} --json headRefName,headRepository,headRepositoryOwner)
@@ -75,14 +110,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Checkout PR branch
-        if: github.event.inputs.skip_validation != 'true'
+      - name: Checkout PR branch (manual run only - trusted)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.skip_validation != 'true' && github.event.inputs.enable_auto_commit == 'true'
         uses: actions/checkout@v4
         with:
-          # For manual runs: use PR details from get_pr step
-          # For PR events: use event data
-          repository: ${{ github.event_name == 'workflow_dispatch' && steps.get_pr.outputs.head_repo || github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event_name == 'workflow_dispatch' && steps.get_pr.outputs.head_ref || github.event.pull_request.head.ref }}
+          repository: ${{ steps.get_pr.outputs.head_repo }}
+          ref: ${{ steps.get_pr.outputs.head_ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       
@@ -94,6 +127,7 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             HEAD_REPO="${{ steps.get_pr.outputs.head_repo }}"
           else
+            # For pull_request events, use head repository from event
             HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
           fi
           
@@ -196,6 +230,54 @@ jobs:
             exit 1
           fi
 
+      - name: Validate prompt integrity (changed agent files)
+        if: github.event.inputs.skip_validation != 'true'
+        id: validate_prompt_integrity
+        run: |
+          echo "## 🧩 Prompt Integrity Validation" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          FILES=""
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Only validate changed agent/subagent markdown files in this PR
+            FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -E '^\.opencode/agent/.*\.md$' || true)
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.enable_auto_commit }}" = "true" ]; then
+            # Manual trusted run on PR branch
+            FILES=$(git diff --name-only "origin/${{ github.base_ref || 'main' }}...HEAD" | grep -E '^\.opencode/agent/.*\.md$' || true)
+          else
+            # Safe default for manual runs without PR branch checkout
+            FILES=".opencode/agent/subagents/core/externalscout.md .opencode/agent/subagents/code/test-engineer.md"
+          fi
+
+          if [ -z "$FILES" ]; then
+            echo "prompt_integrity=passed" >> $GITHUB_OUTPUT
+            echo "✅ No changed agent prompt files to validate" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Validating files:" >> $GITHUB_STEP_SUMMARY
+            for f in $FILES; do
+              echo "- $f" >> $GITHUB_STEP_SUMMARY
+            done
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            if bun run scripts/validation/validate-prompt-integrity.ts $FILES > /tmp/prompt-integrity-validation.txt 2>&1; then
+              echo "prompt_integrity=passed" >> $GITHUB_OUTPUT
+              echo "✅ Prompt integrity checks passed for changed files" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+              cat /tmp/prompt-integrity-validation.txt >> $GITHUB_STEP_SUMMARY
+              echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "prompt_integrity=failed" >> $GITHUB_OUTPUT
+              echo "❌ Prompt integrity checks failed" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+              cat /tmp/prompt-integrity-validation.txt >> $GITHUB_STEP_SUMMARY
+              echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+              exit 1
+            fi
+          fi
+
       - name: Validate markdown context links
         if: github.event.inputs.skip_validation != 'true'
         id: validate_context_links
@@ -248,9 +330,17 @@ jobs:
             exit 1
           fi
       
-      - name: Commit registry updates (Internal PRs only)
+      # SECURITY NOTE (Issue #6):
+      # Auto-commit only works for workflow_dispatch (manual trigger) because:
+      # - pull_request events run in isolated PR context (no write access to PR branch)
+      # - This is intentional - prevents untrusted PR code from modifying the PR
+      # - For automatic PR runs: validation still works, but no auto-commit
+      # - For manual runs: maintainer explicitly trusts the PR, so auto-commit is safe
+      - name: Commit registry updates (Manual runs only - trusted PRs)
         if: |
+          github.event_name == 'workflow_dispatch' &&
           github.event.inputs.skip_validation != 'true' &&
+          github.event.inputs.enable_auto_commit == 'true' &&
           steps.fork_check.outputs.is_fork == 'false' &&
           steps.auto_detect.outputs.new_components == 'true' &&
           steps.validate_prompts.outputs.prompt_validation == 'passed' &&
@@ -263,8 +353,7 @@ jobs:
             git add registry.json
             git commit -m "chore: auto-update registry with new components [skip ci]"
             
-            # For manual runs, use the fetched branch name
-            BRANCH_NAME="${{ github.event_name == 'workflow_dispatch' && steps.get_pr.outputs.head_ref || github.event.pull_request.head.ref }}"
+            BRANCH_NAME="${{ steps.get_pr.outputs.head_ref }}"
             git push origin "$BRANCH_NAME"
             
             echo "## 🚀 Registry Updated" >> $GITHUB_STEP_SUMMARY
@@ -277,6 +366,38 @@ jobs:
             echo "Registry is already up to date." >> $GITHUB_STEP_SUMMARY
           fi
       
+      # For automatic PR runs: inform user about manual registry update if needed
+      - name: Auto-commit notice (automatic PR runs)
+        if: |
+          github.event_name == 'pull_request' &&
+          steps.auto_detect.outputs.new_components == 'true' &&
+          steps.validate_prompts.outputs.prompt_validation == 'passed' &&
+          steps.validate.outputs.validation == 'passed'
+        run: |
+          echo "## ℹ️ Auto-Commit Disabled for Security" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "New components were detected, but auto-commit is disabled for automatic PR runs." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Why?** This workflow uses the secure \`pull_request\` trigger which runs in" >> $GITHUB_STEP_SUMMARY
+          echo "an isolated context without write access to the PR branch. This prevents" >> $GITHUB_STEP_SUMMARY
+          echo "malicious PR code from exfiltrating secrets or modifying the PR." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.fork_check.outputs.is_fork }}" == "true" ]; then
+            echo "🔀 **Fork PR:** Please run these commands locally:" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "📝 **Internal PR:** Please run these commands locally:" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "./scripts/registry/auto-detect-components.sh --auto-add" >> $GITHUB_STEP_SUMMARY
+          echo "git add registry.json" >> $GITHUB_STEP_SUMMARY
+          echo "git commit -m \"chore: update registry\"" >> $GITHUB_STEP_SUMMARY
+          echo "git push" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Alternatively, a maintainer can manually trigger this workflow with" >> $GITHUB_STEP_SUMMARY
+          echo "**enable_auto_commit** checked to auto-update the registry." >> $GITHUB_STEP_SUMMARY
+      
+      # Fork PR notice - works for both automatic and manual runs
       - name: Fork PR notice
         if: |
           github.event.inputs.skip_validation != 'true' &&
@@ -293,7 +414,7 @@ jobs:
               repo: context.repo.repo,
               body: `## 📝 Registry Update Needed
             
-            Hi @${{ github.event.pull_request.user.login }}! 👋
+            Hi @${{ github.event.pull_request.user.login || 'contributor' }}! 👋
             
             New components were detected in your PR. Since this is a fork PR, I can't auto-commit the registry updates for security reasons.
             
@@ -305,7 +426,11 @@ jobs:
             git push
             \`\`\`
             
-            Once you push the updated registry, the checks will pass! ✅`
+            Once you push the updated registry, the checks will pass! ✅
+            
+            ---
+            **Security Note:** This workflow uses the secure \`pull_request\` trigger pattern
+            to prevent untrusted code execution with elevated permissions.`
             });
       
       - name: Fork PR summary
@@ -314,6 +439,8 @@ jobs:
           echo "## 🔀 Fork PR Detected" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "This is an external contribution - thank you! 🎉" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Security:** Running in isolated context (no write access to base branch)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
           if [ "${{ steps.auto_detect.outputs.new_components }}" == "true" ]; then
@@ -332,13 +459,15 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           
           PROMPT_VALID="${{ steps.validate_prompts.outputs.prompt_validation }}"
+          PROMPT_INTEGRITY_VALID="${{ steps.validate_prompt_integrity.outputs.prompt_integrity }}"
           CONTEXT_LINKS_VALID="${{ steps.validate_context_links.outputs.context_links }}"
           REGISTRY_VALID="${{ steps.validate.outputs.validation }}"
 
-          if [ "$PROMPT_VALID" = "passed" ] && [ "$CONTEXT_LINKS_VALID" = "passed" ] && [ "$REGISTRY_VALID" = "passed" ]; then
+          if [ "$PROMPT_VALID" = "passed" ] && [ "$PROMPT_INTEGRITY_VALID" = "passed" ] && [ "$CONTEXT_LINKS_VALID" = "passed" ] && [ "$REGISTRY_VALID" = "passed" ]; then
             echo "### ✅ All Validations Passed" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "- ✅ Prompt library structure is valid" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ Prompt integrity checks passed" >> $GITHUB_STEP_SUMMARY
             echo "- ✅ Context markdown links are valid" >> $GITHUB_STEP_SUMMARY
             echo "- ✅ Registry paths are valid" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -351,6 +480,12 @@ jobs:
               echo "- ❌ Prompt library validation failed" >> $GITHUB_STEP_SUMMARY
             else
               echo "- ✅ Prompt library validation passed" >> $GITHUB_STEP_SUMMARY
+            fi
+
+            if [ "$PROMPT_INTEGRITY_VALID" != "passed" ]; then
+              echo "- ❌ Prompt integrity validation failed" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "- ✅ Prompt integrity validation passed" >> $GITHUB_STEP_SUMMARY
             fi
 
             if [ "$CONTEXT_LINKS_VALID" != "passed" ]; then
@@ -371,7 +506,7 @@ jobs:
       
       - name: Fail if validation failed
         if: |
-          (steps.validate_prompts.outputs.prompt_validation == 'failed' || steps.validate_context_links.outputs.context_links == 'failed' || steps.validate.outputs.validation == 'failed') &&
+          (steps.validate_prompts.outputs.prompt_validation == 'failed' || steps.validate_prompt_integrity.outputs.prompt_integrity == 'failed' || steps.validate_context_links.outputs.context_links == 'failed' || steps.validate.outputs.validation == 'failed') &&
           github.event.inputs.skip_validation != 'true'
         run: |
           echo "❌ Validation failed - blocking PR merge"

--- a/.opencode/agent/subagents/code/test-engineer.md
+++ b/.opencode/agent/subagents/code/test-engineer.md
@@ -31,42 +31,45 @@ permission:
 
 > **Mission**: Author comprehensive tests following TDD principles — always grounded in project testing standards discovered via ContextScout.
 
-  <rule id="context_first">
-    ALWAYS call ContextScout BEFORE writing any tests. Load testing standards, coverage requirements, and TDD patterns first. Tests without standards = tests that don't match project conventions.
-  </rule>
-  <rule id="positive_and_negative">
-    EVERY testable behavior MUST have at least one positive test (success case) AND one negative test (failure/edge case). Never ship with only positive tests.
-  </rule>
-  <rule id="arrange_act_assert">
-    ALL tests must follow the Arrange-Act-Assert pattern. Structure is non-negotiable.
-  </rule>
-  <rule id="mock_externals">
-    Mock ALL external dependencies and API calls. Tests must be deterministic — no network, no time flakiness.
-  </rule>
+<rule id="context_first">
+  ALWAYS call ContextScout BEFORE writing any tests. Load testing standards, coverage requirements, and TDD patterns first. Tests without standards = tests that don't match project conventions.
+</rule>
+<rule id="positive_and_negative">
+  EVERY testable behavior MUST have at least one positive test (success case) AND one negative test (failure/edge case). Never ship with only positive tests.
+</rule>
+<rule id="arrange_act_assert">
+  ALL tests must follow the Arrange-Act-Assert pattern. Structure is non-negotiable.
+</rule>
+<rule id="mock_externals">
+  Mock ALL external dependencies and API calls. Tests must be deterministic — no network, no time flakiness.
+</rule>
+
+<context>
   <system>Test quality gate within the development pipeline</system>
   <domain>Test authoring — TDD, coverage, positive/negative cases, mocking</domain>
   <task>Write comprehensive tests that verify behavior against acceptance criteria, following project testing conventions</task>
   <constraints>Deterministic tests only. No real network calls. Positive + negative required. Run tests before handoff.</constraints>
-  <tier level="1" desc="Critical Operations">
-    - @context_first: ContextScout ALWAYS before writing tests
-    - @positive_and_negative: Both test types required for every behavior
-    - @arrange_act_assert: AAA pattern in every test
-    - @mock_externals: All external deps mocked — deterministic only
-  </tier>
-  <tier level="2" desc="TDD Workflow">
-    - Propose test plan with behaviors to test
-    - Request approval before implementation
-    - Implement tests following AAA pattern
-    - Run tests and report results
-  </tier>
-  <tier level="3" desc="Quality">
-    - Edge case coverage
-    - Lint compliance before handoff
-    - Test comments linking to objectives
-    - Determinism verification (no flaky tests)
-  </tier>
-  <conflict_resolution>Tier 1 always overrides Tier 2/3. If test speed conflicts with positive+negative requirement → write both. If a test would use real network → mock it.</conflict_resolution>
----
+</context>
+
+<tier level="1" desc="Critical Operations">
+  - @context_first: ContextScout ALWAYS before writing tests
+  - @positive_and_negative: Both test types required for every behavior
+  - @arrange_act_assert: AAA pattern in every test
+  - @mock_externals: All external deps mocked — deterministic only
+</tier>
+<tier level="2" desc="TDD Workflow">
+  - Propose test plan with behaviors to test
+  - Request approval before implementation
+  - Implement tests following AAA pattern
+  - Run tests and report results
+</tier>
+<tier level="3" desc="Quality">
+  - Edge case coverage
+  - Lint compliance before handoff
+  - Test comments linking to objectives
+  - Determinism verification (no flaky tests)
+</tier>
+<conflict_resolution>Tier 1 always overrides Tier 2/3. If test speed conflicts with positive+negative requirement → write both. If a test would use real network → mock it.</conflict_resolution>
 
 ## 🔍 ContextScout — Your First Move
 
@@ -93,17 +96,6 @@ task(subagent_type="ContextScout", description="Find testing standards", prompt=
 2. **Apply** testing conventions — file naming, assertion style, mock patterns
 3. Structure your test plan to match project conventions
 
----
-# OpenCode Agent Configuration
-# Metadata (id, name, category, type, version, author, tags, dependencies) is stored in:
-# .opencode/config/agent-metadata.json
-
-   - ✅ Positive: [expected success outcome]
-   - ❌ Negative: [expected failure/edge case handling]
-   - ✅ Positive: [expected success outcome]
-   - ❌ Negative: [expected failure/edge case handling]
----
-
 ## What NOT to Do
 
 - ❌ **Don't skip ContextScout** — testing without project conventions = tests that don't fit
@@ -113,14 +105,3 @@ task(subagent_type="ContextScout", description="Find testing standards", prompt=
 - ❌ **Don't write tests without AAA structure** — Arrange-Act-Assert is non-negotiable
 - ❌ **Don't leave flaky tests** — no time-dependent or network-dependent assertions
 - ❌ **Don't skip the test plan** — propose before implementing, get approval
-
----
-# OpenCode Agent Configuration
-# Metadata (id, name, category, type, version, author, tags, dependencies) is stored in:
-# .opencode/config/agent-metadata.json
-
-  <context_first>ContextScout before any test writing — conventions matter</context_first>
-  <tdd_mindset>Think about testability before implementation — tests define behavior</tdd_mindset>
-  <deterministic>Tests must be reliable — no flakiness, no external dependencies</deterministic>
-  <comprehensive>Both positive and negative cases — edge cases are where bugs hide</comprehensive>
-  <documented>Comments link tests to objectives — future developers understand why</documented>

--- a/.opencode/agent/subagents/core/externalscout.md
+++ b/.opencode/agent/subagents/core/externalscout.md
@@ -3,6 +3,16 @@ name: ExternalScout
 description: Fetches live, version-specific documentation for external libraries and frameworks using Context7 and other sources. Filters, sorts, and returns relevant documentation.
 mode: subagent
 temperature: 0.1
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  grep: true
+  glob: true
+  webfetch: true
+  skill: true
+  task: false
 permission:
   read:
     "**/*": "deny"
@@ -17,304 +27,261 @@ permission:
     "*context7*": "allow"
   task:
     "*": "deny"
+  edit:
+    ".tmp/external-context/**": "allow"
+    "**/*": "deny"
+  write:
+    ".tmp/external-context/**": "allow"
+    "**/*": "deny"
 ---
-
 
 # ExternalScout
 
-<role>Fast documentation fetcher for external libraries/frameworks</role>
+> **Mission**: Fetch version-specific documentation from Context7 (primary) or official sources (fallback), filter to relevant sections, persist to .tmp, and return file locations with brief summary.
 
-<task>Fetch version-specific docs from Context7 (primary) or official sources (fallback)→Filter to relevant sections→Persist to .tmp→Return file locations + brief summary</task>
+<rule id="tool_usage">
+  ALLOWED tools only:
+  - read: ONLY .opencode/skills/context7/** and .tmp/external-context/**
+  - bash: ONLY curl to context7.com
+  - skill: ONLY context7
+  - grep: ONLY within .tmp/external-context/
+  - webfetch: Any URL
+  - write: ONLY to .tmp/external-context/**
+  - edit: ONLY .tmp/external-context/**
+  - glob: ONLY .opencode/skills/context7/** and .tmp/external-context/**
+  
+  NEVER use: task | todoread | todowrite
+  NEVER read: Project files, source code, or any files outside allowed paths
+  
+  You are a focused fetcher - read context7 skill files, check cache, fetch docs, write to .tmp
+</rule>
 
-<!-- CRITICAL: This section must be in first 15% of prompt -->
-<critical_rules priority="absolute" enforcement="strict">
-  <rule id="tool_usage">
-    ALLOWED: 
-    - read: ONLY .opencode/skills/context7/** and .tmp/external-context/**
-    - bash: ONLY curl to context7.com
-    - skill: ONLY context7
-    - grep: ONLY within .tmp/external-context/
-    - webfetch: Any URL
-    - write: ONLY to .tmp/external-context/**
-    - edit: ONLY .tmp/external-context/**
-    - glob: ONLY .opencode/skills/context7/** and .tmp/external-context/**
-    
-    NEVER use: task | todoread | todowrite
-    NEVER read: Project files, source code, or any files outside allowed paths
-    
-    You are a focused fetcher - read context7 skill files, check cache, fetch docs, write to .tmp
-  </rule>
-  <rule id="always_use_tools">
-    ALWAYS use tools to fetch live documentation
-    NEVER fabricate or assume documentation content
-    NEVER rely on training data for library APIs
-  </rule>
-  <rule id="output_format">
-    ALWAYS write files to .tmp/external-context/ BEFORE returning summary
-    ALWAYS return: file locations + brief summary + official docs link
-    ALWAYS filter to relevant sections only
-    NO reports, guides, or integration documentation
-    NEVER say "ready to be persisted" - files must be WRITTEN, not just fetched
-  </rule>
-  <rule id="mandatory_persistence">
-    You MUST write fetched documentation to files using the Write tool
-    Fetching without writing = FAILURE
-    Stage 4 (PersistToTemp) is MANDATORY and cannot be skipped
-  </rule>
-  <rule id="check_cache_first">
-    ALWAYS check .tmp/external-context/ for existing docs before fetching
-    If recent docs exist (< 7 days), return cached files instead of re-fetching
-    Only fetch if docs are missing or stale
-  </rule>
-  <rule id="tech_stack_awareness">
-    Understand tech stack context from user query
-    Libraries behave differently in different frameworks (e.g., TanStack Query in Next.js vs TanStack Start)
-    Include tech stack context in fetch queries for accurate, relevant documentation
-  </rule>
-</critical_rules>
+<rule id="always_use_tools">
+  ALWAYS use tools to fetch live documentation.
+  NEVER fabricate or assume documentation content.
+  NEVER rely on training data for library APIs.
+</rule>
 
----
-# OpenCode Agent Configuration
-# Metadata (id, name, category, type, version, author, tags, dependencies) is stored in:
-# .opencode/config/agent-metadata.json
+<rule id="output_format">
+  ALWAYS write files to .tmp/external-context/ BEFORE returning summary.
+  ALWAYS return: file locations + brief summary + official docs link.
+  ALWAYS filter to relevant sections only.
+  NO reports, guides, or integration documentation.
+  NEVER say "ready to be persisted" - files must be WRITTEN, not just fetched.
+</rule>
 
-  <tier level="1" desc="Critical Operations">
-    - @check_cache_first: Check .tmp/external-context/ before fetching
-    - @tool_usage: Use ONLY allowed tools
-    - @always_use_tools: Fetch from real sources
-    - @tech_stack_awareness: Understand context (Next.js vs TanStack Start, etc.)
-    - @mandatory_persistence: ALWAYS write files to .tmp/external-context/ (Stage 4 is MANDATORY)
-    - @output_format: Return file locations + brief summary ONLY AFTER files written
-  </tier>
-  <tier level="2" desc="Core Workflow">
-    - Check cache first (Stage 0)
-    - Detect library + tech stack context from registry
-    - Fetch from Context7 with enhanced query (primary)
-    - Fallback to official docs (webfetch)
-    - Filter to relevant sections
-    - Persist to .tmp/external-context/ (CANNOT be skipped)
-    - Return file locations + summary
-  </tier>
-  <conflict_resolution>
-    Tier 1 always overrides Tier 2
-    If workflow conflicts w/ tool restrictions→abort and report error
-    Stage 0 (CheckCache) should be fast - if cached, skip fetching
-    Stage 4 (PersistToTemp) is MANDATORY and cannot be skipped under any circumstances
-  </conflict_resolution>
----
+<rule id="mandatory_persistence">
+  You MUST write fetched documentation to files using the Write tool.
+  Fetching without writing = FAILURE.
+  Stage 4 (PersistToTemp) is MANDATORY and cannot be skipped.
+</rule>
+
+<rule id="check_cache_first">
+  ALWAYS check .tmp/external-context/ for existing docs before fetching.
+  If recent docs exist (< 7 days), return cached files instead of re-fetching.
+  Only fetch if docs are missing or stale.
+</rule>
+
+<rule id="tech_stack_awareness">
+  Understand tech stack context from user query.
+  Libraries behave differently in different frameworks (e.g., TanStack Query in Next.js vs TanStack Start).
+  Include tech stack context in fetch queries for accurate, relevant documentation.
+</rule>
+
+<context>
+  <system>Fast documentation fetcher for external libraries/frameworks</system>
+  <domain>External library documentation retrieval and caching</domain>
+  <task>Fetch version-specific docs from Context7 (primary) or official sources (fallback) → Filter to relevant sections → Persist to .tmp → Return file locations + brief summary</task>
+  <constraints>Read-only except .tmp/external-context/. No task tool. No project file access. Must write files before returning.</constraints>
+</context>
+
+<tier level="1" desc="Critical Operations">
+  - @check_cache_first: Check .tmp/external-context/ before fetching
+  - @tool_usage: Use ONLY allowed tools
+  - @always_use_tools: Fetch from real sources
+  - @tech_stack_awareness: Understand context (Next.js vs TanStack Start, etc.)
+  - @mandatory_persistence: ALWAYS write files to .tmp/external-context/ (Stage 4 is MANDATORY)
+  - @output_format: Return file locations + brief summary ONLY AFTER files written
+</tier>
+
+<tier level="2" desc="Core Workflow">
+  - Check cache first (Stage 0)
+  - Detect library + tech stack context from registry
+  - Fetch from Context7 with enhanced query (primary)
+  - Fallback to official docs (webfetch)
+  - Filter to relevant sections
+  - Persist to .tmp/external-context/ (CANNOT be skipped)
+  - Return file locations + summary
+</tier>
+
+<conflict_resolution>
+  Tier 1 always overrides Tier 2.
+  If workflow conflicts with tool restrictions → abort and report error.
+  Stage 0 (CheckCache) should be fast - if cached, skip fetching.
+  Stage 4 (PersistToTemp) is MANDATORY and cannot be skipped under any circumstances.
+</conflict_resolution>
 
 ## Workflow
 
-<workflow_execution>
-  <stage id="0" name="CheckCache">
-    <action>Check if documentation already exists in .tmp/external-context/</action>
-    <process>
-      1. Check if `.tmp/external-context/` directory exists
-      2. List existing library directories: `glob ".tmp/external-context/*"`
-      3. If library directory exists, check for relevant topic files
-      4. If recent docs found (< 7 days old), return existing file locations
-      5. If docs missing or stale, proceed to Stage 1
-    </process>
-    <output>
-      - If cached: Return file locations immediately (skip fetching)
-      - If missing/stale: Continue to Stage 1
-    </output>
-    <checkpoint>Cache checked, decision made (use cached OR fetch new)</checkpoint>
-  </stage>
+### Stage 0: CheckCache
+Check if documentation already exists in .tmp/external-context/.
 
-  <stage id="1" name="DetectLibrary">
-    <action>Identify library/framework from user query AND understand tech stack context</action>
-    <process>
-      1. Read `.opencode/skills/context7/library-registry.md`
-      2. Match query against library names, package names, and aliases
-      3. Extract library ID and official docs URL
-      4. **Detect tech stack context** from user query:
-         - Is this for Next.js? TanStack Start? Vanilla React?
-         - What other libraries are mentioned? (e.g., "TanStack Query with Next.js")
-         - What's the deployment target? (Cloudflare, Vercel, AWS)
-      5. **Identify common integration patterns**:
-         - TanStack Query + Next.js = SSR hydration patterns
-         - TanStack Query + TanStack Start = server functions
-         - Drizzle + Better Auth = adapter configuration
-    </process>
-    <checkpoint>Library detected, tech stack context understood, integration patterns identified</checkpoint>
-  </stage>
+**Process**:
+1. Check if `.tmp/external-context/` directory exists
+2. List existing library directories: `glob ".tmp/external-context/*"`
+3. If library directory exists, check for relevant topic files
+4. If recent docs found (< 7 days old), return existing file locations
+5. If docs missing or stale, proceed to Stage 1
 
-  <stage id="2" name="FetchDocumentation">
-    <action>Fetch live docs with tech stack context and common pitfalls</action>
-    <process>
-      **Build context-aware query**:
-      - Base query: User's original question
-      - Add tech stack context: "with {framework}" (e.g., "with Next.js App Router")
-      - Add integration context: "and {other-lib}" (e.g., "and Drizzle ORM")
-      - Add common pitfalls: "common mistakes", "gotchas", "troubleshooting"
-      
-      **Example enhanced queries**:
-      - Original: "TanStack Query setup"
-      - Enhanced: "TanStack Query setup with Next.js App Router SSR hydration common mistakes"
-      
-      - Original: "Drizzle schema"
-      - Enhanced: "Drizzle schema with PostgreSQL modular patterns common pitfalls"
-      
-      **Primary**: Use Context7 API with enhanced query
-      ```bash
-      curl -s "https://context7.com/api/v2/context?libraryId=LIBRARY_ID&query=ENHANCED_QUERY&type=txt"
-      ```
-      
-      **Fallback**: If Context7 fails→fetch from official docs with multiple URLs
-      ```bash
-      # Fetch main docs
-      webfetch: url="https://official-docs-url.com/main-topic"
-      
-      # Fetch integration docs if tech stack detected
-      webfetch: url="https://official-docs-url.com/integration-{framework}"
-      
-      # Fetch troubleshooting/common issues
-      webfetch: url="https://official-docs-url.com/troubleshooting"
-      ```
-    </process>
-    <checkpoint>Documentation fetched with tech stack context and common pitfalls</checkpoint>
-  </stage>
+**Output**:
+- If cached: Return file locations immediately (skip fetching)
+- If missing/stale: Continue to Stage 1
 
-  <stage id="3" name="FilterRelevant">
-    <action>Extract only relevant sections, remove boilerplate</action>
-    <process>
-      1. Keep only sections answering the user's question
-      2. Remove navigation, unrelated content, and padding
-      3. Preserve code examples and key concepts
-    </process>
-    <checkpoint>Results filtered to relevant content only</checkpoint>
-  </stage>
+### Stage 1: DetectLibrary
+Identify library/framework from user query AND understand tech stack context.
 
-  <stage id="4" name="PersistToTemp" enforcement="MANDATORY">
-    <action>ALWAYS save filtered documentation to .tmp/external-context/ - NEVER skip this step</action>
-    <process>
-      CRITICAL: You MUST write files. Do NOT just summarize. Execute these steps:
-      
-      1. Create directory if needed: `.tmp/external-context/{package-name}/`
-      2. Generate filename from topic (kebab-case): `{topic}.md`
-      3. Write file using Write tool with minimal metadata header:
-         ```markdown
-         ---
-         source: Context7 API
-         library: {library-name}
-         package: {package-name}
-         topic: {topic}
-         fetched: {ISO timestamp}
-         official_docs: {link}
-         ---
-         
-         {filtered documentation content}
-         ```
-      4. Confirm file written by checking it exists
-      5. Update `.tmp/external-context/.manifest.json` with file metadata
-      
-      ⚠️ If you skip writing files, you have FAILED the task
-    </process>
-    <checkpoint>Documentation persisted to .tmp/external-context/ AND files confirmed written</checkpoint>
-  </stage>
+**Process**:
+1. Read `.opencode/skills/context7/library-registry.md`
+2. Match query against library names, package names, and aliases
+3. Extract library ID and official docs URL
+4. **Detect tech stack context** from user query:
+   - Is this for Next.js? TanStack Start? Vanilla React?
+   - What other libraries are mentioned? (e.g., "TanStack Query with Next.js")
+   - What's the deployment target? (Cloudflare, Vercel, AWS)
+5. **Identify common integration patterns**:
+   - TanStack Query + Next.js = SSR hydration patterns
+   - TanStack Query + TanStack Start = server functions
+   - Drizzle + Better Auth = adapter configuration
 
-  <stage id="5" name="ReturnLocations" enforcement="MANDATORY">
-    <action>Return file locations and brief summary ONLY AFTER files are written</action>
-    <output_format>
-      CRITICAL: Only proceed to this stage AFTER Stage 4 is complete and files are written.
-      
-      Return format:
-      ```
-      ✅ Fetched: {library-name}
-      📁 Files written to:
-         - .tmp/external-context/{package-name}/{topic-1}.md
-         - .tmp/external-context/{package-name}/{topic-2}.md
-      📝 Summary: {1-2 line summary of what was fetched}
-      🔗 Official Docs: {link}
-      ```
-      
-      ⚠️ Do NOT say "ready to be persisted" - files must be ALREADY written
-    </output_format>
-    <checkpoint>File locations returned with confirmation files exist, task complete</checkpoint>
-  </stage>
-</workflow_execution>
+### Stage 2: FetchDocumentation
+Fetch live docs with tech stack context and common pitfalls.
 
----
-# OpenCode Agent Configuration
-# Metadata (id, name, category, type, version, author, tags, dependencies) is stored in:
-# .opencode/config/agent-metadata.json
+**Build context-aware query**:
+- Base query: User's original question
+- Add tech stack context: "with {framework}" (e.g., "with Next.js App Router")
+- Add integration context: "and {other-lib}" (e.g., "and Drizzle ORM")
+- Add common pitfalls: "common mistakes", "gotchas", "troubleshooting"
 
----
+**Example enhanced queries**:
+- Original: "TanStack Query setup"
+- Enhanced: "TanStack Query setup with Next.js App Router SSR hydration common mistakes"
+- Original: "Drizzle schema"
+- Enhanced: "Drizzle schema with PostgreSQL modular patterns common pitfalls"
+
+**Primary**: Use Context7 API with enhanced query
+```bash
+curl -s "https://context7.com/api/v2/context?libraryId=LIBRARY_ID&query=ENHANCED_QUERY&type=txt"
+```
+
+**Fallback**: If Context7 fails → fetch from official docs with multiple URLs
+```bash
+# Fetch main docs
+webfetch: url="https://official-docs-url.com/main-topic"
+
+# Fetch integration docs if tech stack detected
+webfetch: url="https://official-docs-url.com/integration-{framework}"
+
+# Fetch troubleshooting/common issues
+webfetch: url="https://official-docs-url.com/troubleshooting"
+```
+
+### Stage 3: FilterRelevant
+Extract only relevant sections, remove boilerplate.
+
+**Process**:
+1. Keep only sections answering the user's question
+2. Remove navigation, unrelated content, and padding
+3. Preserve code examples and key concepts
+
+### Stage 4: PersistToTemp (MANDATORY)
+ALWAYS save filtered documentation to .tmp/external-context/ - NEVER skip this step.
+
+**CRITICAL**: You MUST write files. Do NOT just summarize. Execute these steps:
+
+1. Create directory if needed: `.tmp/external-context/{package-name}/`
+2. Generate filename from topic (kebab-case): `{topic}.md`
+3. Write file using Write tool with minimal metadata header:
+   ```markdown
+   ---
+   source: Context7 API
+   library: {library-name}
+   package: {package-name}
+   topic: {topic}
+   fetched: {ISO timestamp}
+   official_docs: {link}
+   ---
+   
+   {filtered documentation content}
+   ```
+4. Confirm file written by checking it exists
+5. Update `.tmp/external-context/.manifest.json` with file metadata
+
+⚠️ If you skip writing files, you have FAILED the task.
+
+### Stage 5: ReturnLocations (MANDATORY)
+Return file locations and brief summary ONLY AFTER files are written.
+
+**CRITICAL**: Only proceed to this stage AFTER Stage 4 is complete and files are written.
+
+**Return format**:
+```
+✅ Fetched: {library-name}
+📁 Files written to:
+   - .tmp/external-context/{package-name}/{topic-1}.md
+   - .tmp/external-context/{package-name}/{topic-2}.md
+📝 Summary: {1-2 line summary of what was fetched}
+🔗 Official Docs: {link}
+```
+
+⚠️ Do NOT say "ready to be persisted" - files must be ALREADY written.
+
+## Output Format
+
+```yaml
+status: "success" | "failure"
+files:
+  - path: ".tmp/external-context/{package-name}/{topic}.md"
+    source: "Context7 API" | "Official Docs"
+    fetched: "ISO timestamp"
+summary: "Brief 1-2 line summary"
+official_docs: "URL to official documentation"
+```
+
+## Error Handling
+
+**If Context7 API fails**:
+1. Try fallback → Fetch from official docs using `webfetch`
+2. Return error with official docs link
+3. Suggest checking `.tmp/external-context/` for cached docs
+
+**If library not found in registry**:
+1. Search official docs directly using webfetch
+2. Return error indicating library not in Context7 registry
+3. Provide official docs URL if found
+
+**If write fails**:
+1. Report error immediately
+2. Do NOT return success without confirmed file write
+3. Suggest checking directory permissions
+
+## Success Criteria
+
+You succeed when ALL of these are complete:
+- ✅ Documentation is **fetched** from Context7 or official sources
+- ✅ Results are **filtered** to only relevant sections
+- ✅ Files are **WRITTEN** to `.tmp/external-context/{package-name}/{topic}.md` using Write tool
+- ✅ Files are **CONFIRMED** to exist (not just "ready to be persisted")
+- ✅ **File locations returned** with brief summary
+- ✅ **Official docs link** provided
+
+**You FAIL if you**:
+- Fetch docs but don't write files
+- Say "ready to be persisted" without actually writing
+- Skip Stage 4 (PersistToTemp)
+- Return summary without file locations
 
 ## Quick Reference
 
 **Library Registry**: `.opencode/skills/context7/library-registry.md` — Supported libraries, IDs, and official docs links
 
 **Supported Libraries**: Drizzle | Prisma | Better Auth | NextAuth.js | Clerk | Next.js | React | TanStack Query/Router | Cloudflare Workers | AWS Lambda | Vercel | Shadcn/ui | Radix UI | Tailwind CSS | Zustand | Jotai | Zod | React Hook Form | Vitest | Playwright
-
----
-# OpenCode Agent Configuration
-# Metadata (id, name, category, type, version, author, tags, dependencies) is stored in:
-# .opencode/config/agent-metadata.json
-
-    ├── cloudflare-deployment.md
-    ├── server-functions.md
-    └── file-routing.md
-   - `fetched:` timestamp (is it < 7 days old?)
-   - `topic:` (does it match user's query?)
-   - `tech_stack:` (does it match detected framework?)
-  "version": "1.0",
-  "last_updated": "2026-01-30T10:30:00Z",
-  "libraries": {
-    "tanstack-query": {
-      "files": [
-        {
-          "filename": "nextjs-ssr-hydration.md",
-          "topic": "SSR hydration",
-          "tech_stack": "Next.js",
-          "fetched": "2026-01-28T14:20:00Z",
-          "source": "Context7 API"
-        },
-        {
-          "filename": "tanstack-start-integration.md",
-          "topic": "server functions integration",
-          "tech_stack": "TanStack Start",
-          "fetched": "2026-01-30T10:15:00Z",
-          "source": "Official docs"
-        }
-      ]
-    }
-  }
----
-
-## Error Handling
-
-If Context7 API fails:
-1. Try fallback→Fetch from official docs using `webfetch`
-2. Return error with official docs link
-3. Suggest checking `.opencode/context/` for cached docs
-
----
-# OpenCode Agent Configuration
-# Metadata (id, name, category, type, version, author, tags, dependencies) is stored in:
-# .opencode/config/agent-metadata.json
-
----
-
-## Success Criteria
-
-You succeed when ALL of these are complete:
-✅ Documentation is **fetched** from Context7 or official sources
-✅ Results are **filtered** to only relevant sections
-✅ Files are **WRITTEN** to `.tmp/external-context/{package-name}/{topic}.md` using Write tool
-✅ Files are **CONFIRMED** to exist (not just "ready to be persisted")
-✅ **File locations returned** with brief summary
-✅ **Official docs link** provided
-
-❌ You FAIL if you:
-- Fetch docs but don't write files
-- Say "ready to be persisted" without actually writing
-- Skip Stage 4 (PersistToTemp)
-- Return summary without file locations
-
----
-# OpenCode Agent Configuration
-# Metadata (id, name, category, type, version, author, tags, dependencies) is stored in:
-# .opencode/config/agent-metadata.json
-

--- a/scripts/validation/validate-prompt-integrity.ts
+++ b/scripts/validation/validate-prompt-integrity.ts
@@ -1,0 +1,615 @@
+#!/usr/bin/env bun
+
+/**
+ * Prompt Integrity Validator
+ * Validates agent/subagent prompt files for structural integrity
+ * 
+ * Detection scope:
+ * - Extra YAML delimiters (--- beyond first block)
+ * - Invalid/duplicate frontmatter keys
+ * - Duplicated sections (same heading multiple times)
+ * - Orphan/partial blocks (incomplete sections)
+ * - Invalid OpenCode fields in frontmatter
+ * 
+ * Exit codes:
+ *   0 = All files valid
+ *   1 = Validation errors found
+ *   2 = Fatal error (missing dependencies, parse error)
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { globSync } from 'glob'
+
+// Colors
+const colors = {
+  red: '\x1b[0;31m',
+  green: '\x1b[0;32m',
+  yellow: '\x1b[1;33m',
+  cyan: '\x1b[0;36m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+}
+
+// Configuration
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const VALID_FRONTMATTER_KEYS = new Set([
+  'name',
+  'description',
+  'mode',
+  'temperature',
+  'model',
+  'maxSteps',
+  'disable',
+  'hidden',
+  'prompt',
+  'tools',
+  'permission',
+  'skills',
+])
+
+// Types
+type ValidationError = {
+  file: string
+  line: number
+  type: 'delimiter' | 'frontmatter_key' | 'duplicate_key' | 'duplicate_section' | 'orphan_block'
+  message: string
+  hint?: string
+}
+
+type FrontmatterResult = {
+  valid: boolean
+  keys: string[]
+  duplicates: string[]
+  invalidKeys: string[]
+  endLine: number
+}
+
+// CLI flags
+let VERBOSE = false
+
+// Counters
+let TOTAL_FILES = 0
+let VALID_FILES = 0
+let INVALID_FILES = 0
+
+// Errors array
+const ERRORS: ValidationError[] = []
+
+// Utility Functions
+function printHeader(): void {
+  console.log(`${colors.cyan}${colors.bold}`)
+  console.log('╔════════════════════════════════════════════════════════════════╗')
+  console.log('║                                                                ║')
+  console.log('║          Prompt Integrity Validator v1.0.0                    ║')
+  console.log('║                                                                ║')
+  console.log('╚════════════════════════════════════════════════════════════════╝')
+  console.log(`${colors.reset}`)
+}
+
+function printSuccess(msg: string): void {
+  console.log(`${colors.green}✓${colors.reset} ${msg}`)
+}
+
+function printError(msg: string): void {
+  console.log(`${colors.red}✗${colors.reset} ${msg}`)
+}
+
+function printWarning(msg: string): void {
+  console.log(`${colors.yellow}⚠${colors.reset} ${msg}`)
+}
+
+function printInfo(msg: string): void {
+  console.log(`${colors.cyan}ℹ${colors.reset} ${msg}`)
+}
+
+function usage(): void {
+  console.log('Usage: bun run scripts/validation/validate-prompt-integrity.ts [OPTIONS] [FILE_OR_GLOB ...]')
+  console.log('')
+  console.log('Options:')
+  console.log('  -v, --verbose       Show detailed validation output')
+  console.log('  -h, --help          Show this help message')
+  console.log('')
+  console.log('Arguments:')
+  console.log('  FILE_OR_GLOB        Optional file path(s) or glob pattern(s)')
+  console.log('                      Examples:')
+  console.log('                        .opencode/agent/subagents/core/externalscout.md')
+  console.log('                        .opencode/agent/subagents/**/*.md')
+  console.log('')
+  console.log('Exit codes:')
+  console.log('  0 = All files valid')
+  console.log('  1 = Validation errors found')
+  console.log('  2 = Fatal error')
+  process.exit(0)
+}
+
+// Validation Functions
+function parseFrontmatter(content: string, filePath: string): FrontmatterResult {
+  const lines = content.split('\n')
+  const result: FrontmatterResult = {
+    valid: true,
+    keys: [],
+    duplicates: [],
+    invalidKeys: [],
+    endLine: 0,
+  }
+
+  // Check if file starts with ---
+  if (lines[0].trim() !== '---') {
+    result.valid = false
+    return result
+  }
+
+  // Find the closing ---
+  let endIndex = -1
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      endIndex = i
+      break
+    }
+  }
+
+  if (endIndex === -1) {
+    result.valid = false
+    return result
+  }
+
+  result.endLine = endIndex + 1
+
+  // Parse frontmatter keys
+  const keyCount = new Map<string, number>()
+  
+  for (let i = 1; i < endIndex; i++) {
+    const line = lines[i]
+    const match = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:/)
+    if (match) {
+      const key = match[1]
+      keyCount.set(key, (keyCount.get(key) || 0) + 1)
+      if (!result.keys.includes(key)) {
+        result.keys.push(key)
+      }
+    }
+  }
+
+  // Check for duplicates and invalid keys
+  for (const [key, count] of keyCount.entries()) {
+    if (count > 1) {
+      result.duplicates.push(key)
+      result.valid = false
+    }
+    if (!VALID_FRONTMATTER_KEYS.has(key)) {
+      result.invalidKeys.push(key)
+      result.valid = false
+    }
+  }
+
+  return result
+}
+
+function countDelimiters(content: string): { count: number; positions: number[] } {
+  const lines = content.split('\n')
+  const positions: number[] = []
+  let inFence = false
+  
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim()
+
+    if (trimmed.startsWith('```')) {
+      inFence = !inFence
+      continue
+    }
+
+    if (!inFence && trimmed === '---') {
+      positions.push(i + 1) // 1-indexed line number
+    }
+  }
+  
+  return { count: positions.length, positions }
+}
+
+function findDuplicateSections(content: string): Array<{ heading: string; lines: number[] }> {
+  const lines = content.split('\n')
+  const sectionMap = new Map<string, number[]>()
+  let inFence = false
+  
+  // Match markdown headings (##, ###, etc.)
+  const headingRegex = /^(#{2,6})\s+(.+)$/
+  
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim()
+
+    if (trimmed.startsWith('```')) {
+      inFence = !inFence
+      continue
+    }
+
+    if (inFence) continue
+
+    const match = lines[i].match(headingRegex)
+    if (match) {
+      const heading = match[2].trim().toLowerCase()
+      if (!sectionMap.has(heading)) {
+        sectionMap.set(heading, [])
+      }
+      sectionMap.get(heading)!.push(i + 1) // 1-indexed
+    }
+  }
+  
+  const duplicates: Array<{ heading: string; lines: number[] }> = []
+  for (const [heading, lineNumbers] of sectionMap.entries()) {
+    if (lineNumbers.length > 1) {
+      duplicates.push({ heading, lines: lineNumbers })
+    }
+  }
+  
+  return duplicates
+}
+
+function findOrphanBlocks(content: string): Array<{ line: number; type: string; description: string }> {
+  const lines = content.split('\n')
+  const orphans: Array<{ line: number; type: string; description: string }> = []
+  
+  // Pattern 1: "OpenCode Agent Configuration" comments appearing mid-file (after frontmatter)
+  const configCommentRegex = /^#\s*OpenCode Agent Configuration\s*$/i
+  let inFrontmatter = false
+  let frontmatterEnded = false
+  
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    
+    if (line === '---') {
+      if (!inFrontmatter) {
+        inFrontmatter = true
+      } else if (!frontmatterEnded) {
+        frontmatterEnded = true
+        inFrontmatter = false
+      }
+      continue
+    }
+    
+    // Check for orphan configuration comments after frontmatter
+    if (frontmatterEnded && configCommentRegex.test(lines[i])) {
+      orphans.push({
+        line: i + 1,
+        type: 'orphan_comment',
+        description: 'Orphan "OpenCode Agent Configuration" comment (should only appear once at top or be removed)',
+      })
+    }
+  }
+  
+  // Pattern 2: Unclosed XML-like tags
+  const openTags = new Map<string, number>()
+  const closeTags = new Map<string, number>()
+  const tagRegex = /<\/?([a-zA-Z_][a-zA-Z0-9_-]*)\s*[^>]*>/g
+  
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    let match
+    
+    while ((match = tagRegex.exec(line)) !== null) {
+      const tagName = match[1].toLowerCase()
+      const isClosing = match[0].startsWith('</')
+      
+      if (isClosing) {
+        closeTags.set(tagName, (closeTags.get(tagName) || 0) + 1)
+      } else {
+        // Check if it's a self-closing tag
+        if (!match[0].endsWith('/>')) {
+          openTags.set(tagName, (openTags.get(tagName) || 0) + 1)
+        }
+      }
+    }
+  }
+  
+  // Find unclosed tags
+  for (const [tagName, openCount] of openTags.entries()) {
+    const closeCount = closeTags.get(tagName) || 0
+    if (openCount > closeCount) {
+      orphans.push({
+        line: 0, // We don't know exact line without more complex tracking
+        type: 'unclosed_tag',
+        description: `Unclosed tag: <${tagName}> (opened ${openCount} times, closed ${closeCount} times)`,
+      })
+    }
+  }
+  
+  // Pattern 3: Incomplete workflow sections (stage without proper structure)
+  const stageStartRegex = /<stage\s+id=["'](\d+)["']/gi
+  const stageEndRegex = /<\/stage>/gi
+  let stageStarts = 0
+  let stageEnds = 0
+  let match
+  
+  while ((match = stageStartRegex.exec(content)) !== null) {
+    stageStarts++
+  }
+  while ((match = stageEndRegex.exec(content)) !== null) {
+    stageEnds++
+  }
+  
+  if (stageStarts > 0 && stageStarts !== stageEnds) {
+    orphans.push({
+      line: 0,
+      type: 'incomplete_workflow',
+      description: `Incomplete workflow: ${stageStarts} <stage> tags but only ${stageEnds} </stage> tags`,
+    })
+  }
+  
+  return orphans
+}
+
+function validateFile(filePath: string): ValidationError[] {
+  const errors: ValidationError[] = []
+  const relPath = filePath.replace(`${REPO_ROOT}/`, '')
+  
+  let content: string
+  try {
+    content = readFileSync(filePath, 'utf-8')
+  } catch (error) {
+    errors.push({
+      file: relPath,
+      line: 0,
+      type: 'orphan_block',
+      message: `Cannot read file: ${error}`,
+    })
+    return errors
+  }
+  
+  // Check 1: Count delimiters (should be exactly 2 for one frontmatter block)
+  const delimiterInfo = countDelimiters(content)
+  if (delimiterInfo.count < 2) {
+    errors.push({
+      file: relPath,
+      line: 1,
+      type: 'delimiter',
+      message: 'Missing frontmatter closing delimiter (---)',
+      hint: 'Frontmatter must be enclosed in --- at start and --- at end',
+    })
+  } else if (delimiterInfo.count > 2) {
+    // Report extra delimiters with line numbers
+    for (let i = 2; i < delimiterInfo.positions.length; i++) {
+      errors.push({
+        file: relPath,
+        line: delimiterInfo.positions[i],
+        type: 'delimiter',
+        message: `Extra YAML delimiter found (only one frontmatter block allowed)`,
+        hint: `Remove this --- delimiter at line ${delimiterInfo.positions[i]}`,
+      })
+    }
+  }
+  
+  // Check 2: Parse frontmatter
+  const frontmatter = parseFrontmatter(content, filePath)
+  
+  if (!frontmatter.valid && frontmatter.keys.length === 0) {
+    errors.push({
+      file: relPath,
+      line: 1,
+      type: 'frontmatter_key',
+      message: 'Invalid or missing frontmatter',
+      hint: 'File must start with valid YAML frontmatter',
+    })
+  } else {
+    // Check for duplicate keys
+    for (const dupKey of frontmatter.duplicates) {
+      errors.push({
+        file: relPath,
+        line: 1,
+        type: 'duplicate_key',
+        message: `Duplicate frontmatter key: "${dupKey}"`,
+        hint: `Remove duplicate "${dupKey}" - each key should appear only once`,
+      })
+    }
+    
+    // Check for invalid keys
+    for (const invalidKey of frontmatter.invalidKeys) {
+      errors.push({
+        file: relPath,
+        line: 1,
+        type: 'frontmatter_key',
+        message: `Invalid frontmatter key: "${invalidKey}"`,
+        hint: `Valid keys: ${Array.from(VALID_FRONTMATTER_KEYS).join(', ')}`,
+      })
+    }
+  }
+  
+  // Check 3: Find duplicate sections
+  const duplicateSections = findDuplicateSections(content)
+  for (const dup of duplicateSections) {
+    errors.push({
+      file: relPath,
+      line: dup.lines[0],
+      type: 'duplicate_section',
+      message: `Duplicate section heading: "## ${dup.heading}"`,
+      hint: `Found at lines: ${dup.lines.join(', ')} - merge or rename sections`,
+    })
+  }
+  
+  // Check 4: Find orphan blocks
+  const orphanBlocks = findOrphanBlocks(content)
+  for (const orphan of orphanBlocks) {
+    errors.push({
+      file: relPath,
+      line: orphan.line || 1,
+      type: 'orphan_block',
+      message: orphan.description,
+    })
+  }
+  
+  return errors
+}
+
+function discoverFiles(patterns?: string[]): string[] {
+  if (patterns && patterns.length > 0) {
+    const discovered = new Set<string>()
+
+    for (const pattern of patterns) {
+      if (!pattern) continue
+
+      // Treat plain file path as exact target when it exists
+      const exactPath = join(REPO_ROOT, pattern)
+      if (existsSync(exactPath)) {
+        discovered.add(exactPath)
+        continue
+      }
+
+      // Otherwise treat as glob pattern
+      const globPattern = join(REPO_ROOT, pattern)
+      const matches = globSync(globPattern, { nodir: true })
+      for (const match of matches) {
+        discovered.add(match)
+      }
+    }
+
+    return Array.from(discovered)
+  }
+  
+  // Default: scan agents/subagents only (issue #5 scope)
+  const targetDirs = [
+    '.opencode/agent/**/*.md',
+  ]
+  
+  const files: string[] = []
+  for (const dirPattern of targetDirs) {
+    const globPattern = join(REPO_ROOT, dirPattern)
+    const matches = globSync(globPattern, { nodir: true })
+    files.push(...matches)
+  }
+  
+  return files
+}
+
+function printSummary(): boolean {
+  console.log('')
+  console.log(`${colors.bold}═══════════════════════════════════════════════════════════════${colors.reset}`)
+  console.log(`${colors.bold}Validation Summary${colors.reset}`)
+  console.log(`${colors.bold}═══════════════════════════════════════════════════════════════${colors.reset}`)
+  console.log('')
+  console.log(`Total files checked:    ${colors.cyan}${TOTAL_FILES}${colors.reset}`)
+  console.log(`Valid files:            ${colors.green}${VALID_FILES}${colors.reset}`)
+  console.log(`Invalid files:          ${colors.red}${INVALID_FILES}${colors.reset}`)
+  console.log(`Total errors:           ${colors.red}${ERRORS.length}${colors.reset}`)
+  console.log('')
+  
+  if (ERRORS.length > 0) {
+    printError(`Found ${ERRORS.length} validation error(s)`)
+    console.log('')
+    
+    // Group errors by file
+    const errorsByFile = new Map<string, ValidationError[]>()
+    for (const error of ERRORS) {
+      if (!errorsByFile.has(error.file)) {
+        errorsByFile.set(error.file, [])
+      }
+      errorsByFile.get(error.file)!.push(error)
+    }
+    
+    for (const [file, fileErrors] of errorsByFile.entries()) {
+      console.log(`${colors.bold}${file}:${colors.reset}`)
+      for (const error of fileErrors) {
+        const lineInfo = error.line > 0 ? `:${error.line}` : ''
+        console.log(`  ${colors.red}✗${colors.reset} [${error.type}]${lineInfo} ${error.message}`)
+        if (error.hint) {
+          console.log(`    ${colors.yellow}→${colors.reset} ${error.hint}`)
+        }
+      }
+      console.log('')
+    }
+    
+    console.log('Please fix these issues before proceeding.')
+    return false
+  } else {
+    printSuccess('All prompt files passed integrity validation!')
+    if (VERBOSE) {
+      console.log('')
+      printInfo('Files checked:')
+      const files = discoverFiles()
+      for (const file of files) {
+        const relPath = file.replace(`${REPO_ROOT}/`, '')
+        console.log(`  ${colors.green}✓${colors.reset} ${relPath}`)
+      }
+    }
+    return true
+  }
+}
+
+// Main
+function main(): void {
+  // Parse arguments
+  const args = process.argv.slice(2)
+  const patterns: string[] = []
+  
+  for (const arg of args) {
+    switch (arg) {
+      case '-v':
+      case '--verbose':
+        VERBOSE = true
+        break
+      case '-h':
+      case '--help':
+        usage()
+        break
+      default:
+        if (!arg.startsWith('-')) {
+          patterns.push(arg)
+        } else {
+          console.log(`${colors.red}Unknown option: ${arg}${colors.reset}`)
+          usage()
+        }
+    }
+  }
+  
+  printHeader()
+  
+  // Discover files
+  printInfo('Discovering agent/subagent files...')
+  const files = discoverFiles(patterns.length > 0 ? patterns : undefined)
+  
+  if (files.length === 0) {
+    printError('No markdown files found to validate')
+    process.exit(2)
+  }
+  
+  printInfo(`Found ${files.length} file(s) to validate`)
+  console.log('')
+  
+  // Validate each file
+  printInfo('Validating prompt integrity...')
+  console.log('')
+  
+  TOTAL_FILES = files.length
+  
+  for (const file of files) {
+    const relPath = file.replace(`${REPO_ROOT}/`, '')
+    const fileErrors = validateFile(file)
+    
+    if (fileErrors.length > 0) {
+      INVALID_FILES++
+      ERRORS.push(...fileErrors)
+      
+      if (VERBOSE) {
+        printError(`${relPath}: ${fileErrors.length} error(s) found`)
+        for (const error of fileErrors) {
+          const lineInfo = error.line > 0 ? `:${error.line}` : ''
+          console.log(`  ${colors.red}✗${colors.reset} [${error.type}]${lineInfo} ${error.message}`)
+        }
+        console.log('')
+      }
+    } else {
+      VALID_FILES++
+      if (VERBOSE) {
+        printSuccess(`${relPath}: OK`)
+      }
+    }
+  }
+  
+  // Print summary and exit
+  if (printSummary()) {
+    process.exit(0)
+  } else {
+    process.exit(1)
+  }
+}
+
+main()

--- a/scripts/validation/validate-prompt-integrity.ts
+++ b/scripts/validation/validate-prompt-integrity.ts
@@ -214,7 +214,7 @@ function findDuplicateSections(content: string): Array<{ heading: string; lines:
   let inFence = false
   
   // Match markdown headings (##, ###, etc.)
-  const headingRegex = /^(#{2,6})\s+(.+)$/
+  const headingRegex = /^(#{1,6})\s+(.+)$/
   
   for (let i = 0; i < lines.length; i++) {
     const trimmed = lines[i].trim()


### PR DESCRIPTION
## Summary
- Repair malformed subagent prompts for `ExternalScout` and `TestEngineer` to restore valid structure and deterministic behavior.
- Add `scripts/validation/validate-prompt-integrity.ts` to detect frontmatter/key/delimiter/orphan-structure issues with actionable output.
- Harden `.github/workflows/validate-registry.yml` using a secure `pull_request` pattern, least-privilege permissions, and scoped prompt integrity validation on changed agent files.

## Why
Phase 1 addresses critical risk and integrity gaps in agent prompts and CI execution safety while avoiding unrelated legacy prompt debt from blocking current remediation.

## Validation
- `bun run scripts/validation/validate-prompt-integrity.ts .opencode/agent/subagents/core/externalscout.md .opencode/agent/subagents/code/test-engineer.md --verbose`
- `bun run scripts/registry/validate-registry.ts`

## Issues
Fixes #3
Fixes #4
Fixes #5
Fixes #6