### PR TITLE
fix: phase 2B evaluator canonical mapping and package policy review fixes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -163,6 +163,7 @@ jobs:
       has-evals: ${{ steps.filter.outputs.evals }}
       has-docs: ${{ steps.filter.outputs.docs }}
       has-workflows: ${{ steps.filter.outputs.workflows }}
+      has-package-policy-impact: ${{ steps.filter.outputs.package_policy_impact }}
     
     steps:
       - name: Checkout code
@@ -205,6 +206,15 @@ jobs:
           else
             echo "has-workflows=false" >> $GITHUB_OUTPUT
             echo "ℹ️ No workflow changes"
+          fi
+
+          # Check for package-manager policy impact
+          if echo "$CHANGED_FILES" | grep -Eq "^(package.json|package-lock.json|scripts/validation/validate-package-manager-policy.ts|docs/package-manager-policy.md|packages/plugin-abilities/bun.lock|\.opencode/plugin/bun.lock|\.opencode/tool/bun.lock|\.opencode/package-lock.json|packages/compatibility-layer/package-lock.json)$"; then
+            echo "package_policy_impact=true" >> $GITHUB_OUTPUT
+            echo "✅ Package manager policy-impacting changes detected"
+          else
+            echo "package_policy_impact=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No package manager policy-impacting changes"
           fi
 
   build-check:
@@ -261,10 +271,45 @@ jobs:
           echo "- TypeScript errors: Fix type issues in \`evals/framework/src/\`" >> $GITHUB_STEP_SUMMARY
           echo "- YAML validation: Check test files in \`evals/agents/*/tests/\`" >> $GITHUB_STEP_SUMMARY
 
+  package-manager-policy-check:
+    name: Package Manager Policy Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [pr-title-check, check-changes]
+    if: |
+      needs.pr-title-check.outputs.title-valid == 'true' &&
+      needs.check-changes.outputs.has-package-policy-impact == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Validate package manager policy
+        run: npm run validate:package-manager-policy
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "## ✅ Package Manager Policy Check Passed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Lockfile/package-manager policy validation passed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Failure summary
+        if: failure()
+        run: |
+          echo "## ❌ Package Manager Policy Check Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Run locally: \`npm run validate:package-manager-policy\`" >> $GITHUB_STEP_SUMMARY
+
   summary:
     name: PR Checks Summary
     runs-on: ubuntu-latest
-    needs: [pr-title-check, check-changes, build-check]
+    needs: [pr-title-check, check-changes, build-check, package-manager-policy-check]
     if: always()
     
     steps:
@@ -295,6 +340,10 @@ jobs:
             if [ "${{ needs.check-changes.outputs.has-workflows }}" == "true" ]; then
               echo "  - ⚙️ Workflow changes detected" >> $GITHUB_STEP_SUMMARY
             fi
+
+            if [ "${{ needs.check-changes.outputs.has-package-policy-impact }}" == "true" ]; then
+              echo "  - 📦 Package manager policy-impacting changes detected" >> $GITHUB_STEP_SUMMARY
+            fi
           else
             echo "⏭️ **Changed Files:** Skipped (title validation failed)" >> $GITHUB_STEP_SUMMARY
           fi
@@ -307,12 +356,22 @@ jobs:
           elif [ "${{ needs.build-check.result }}" == "failure" ]; then
             echo "❌ **Build & Validate:** Failed - check logs" >> $GITHUB_STEP_SUMMARY
           fi
+
+          # Package Manager Policy Check
+          if [ "${{ needs.package-manager-policy-check.result }}" == "success" ]; then
+            echo "✅ **Package Manager Policy:** Passed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.package-manager-policy-check.result }}" == "skipped" ]; then
+            echo "⏭️ **Package Manager Policy:** Skipped (no policy-impacting changes)" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.package-manager-policy-check.result }}" == "failure" ]; then
+            echo "❌ **Package Manager Policy:** Failed - check logs" >> $GITHUB_STEP_SUMMARY
+          fi
           
           echo "" >> $GITHUB_STEP_SUMMARY
           
           # Overall status
           if [ "${{ needs.pr-title-check.result }}" == "success" ] && \
-             ([ "${{ needs.build-check.result }}" == "success" ] || [ "${{ needs.build-check.result }}" == "skipped" ]); then
+             ([ "${{ needs.build-check.result }}" == "success" ] || [ "${{ needs.build-check.result }}" == "skipped" ]) && \
+             ([ "${{ needs.package-manager-policy-check.result }}" == "success" ] || [ "${{ needs.package-manager-policy-check.result }}" == "skipped" ]); then
             echo "### ✅ All Required Checks Passed!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "This PR is ready for review." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -160,9 +160,9 @@ jobs:
     needs: pr-title-check
     if: needs.pr-title-check.outputs.title-valid == 'true'
     outputs:
-      has-evals: ${{ steps.filter.outputs.evals }}
-      has-docs: ${{ steps.filter.outputs.docs }}
-      has-workflows: ${{ steps.filter.outputs.workflows }}
+      has-evals: ${{ steps.filter.outputs.has-evals }}
+      has-docs: ${{ steps.filter.outputs.has-docs }}
+      has-workflows: ${{ steps.filter.outputs.has-workflows }}
       has-package-policy-impact: ${{ steps.filter.outputs.package_policy_impact }}
     
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -274,6 +274,8 @@ jobs:
   package-manager-policy-check:
     name: Package Manager Policy Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 5
     needs: [pr-title-check, check-changes]
     if: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -209,8 +209,7 @@ jobs:
           fi
 
           # Check for package-manager policy impact
-          if echo "$CHANGED_FILES" | grep -Eq "^(package.json|package-lock.json|scripts/validation/validate-package-manager-policy.ts|docs/package-manager-policy.md|packages/plugin-abilities/bun.lock|\.opencode/plugin/bun.lock|\.opencode/tool/bun.lock|\.opencode/package-lock.json|packages/compatibility-layer/package-lock.json)$"; then
-            echo "package_policy_impact=true" >> $GITHUB_OUTPUT
+          if echo "$CHANGED_FILES" | grep -Eq "(^|/)(package.json|package-lock.json|bun.lock|yarn.lock|pnpm-lock.yaml)$|^(scripts/validation/validate-package-manager-policy.ts|docs/package-manager-policy.md)$"; then
             echo "✅ Package manager policy-impacting changes detected"
           else
             echo "package_policy_impact=false" >> $GITHUB_OUTPUT

--- a/docs/package-manager-policy.md
+++ b/docs/package-manager-policy.md
@@ -1,0 +1,81 @@
+# Package Manager and Lockfile Policy
+
+## Why this policy exists
+
+This repository contains a mix of npm-managed workspaces and Bun-managed runtime/tooling islands.
+To keep installs reproducible and CI behavior stable, we define one clear authority model and explicit exceptions.
+
+## Authority model
+
+### Root repository authority
+
+- **Package manager authority (root):** `npm`
+- **Lockfile authority (root):** `package-lock.json`
+
+Contributors must run dependency install/update flows from the root with npm (`npm install`, `npm ci`, `npm update`) when changing root/workspace dependencies.
+
+### Allowed Bun islands (explicit exceptions)
+
+The following paths are intentionally Bun-managed today:
+
+- `packages/plugin-abilities` (current mixed-reality package)
+- `.opencode/plugin`
+- `.opencode/tool`
+
+These locations are allowed to use `bun.lock`.
+
+### Transitional root Bun lockfile
+
+`bun.lock` may exist at repository root as a compatibility/transitional artifact, but it is **not** the root authority lockfile.
+Root dependency truth remains `package-lock.json`.
+
+## Allowed combinations
+
+### Allowed
+
+- Root `package.json` + root `package-lock.json`
+- `packages/plugin-abilities/package.json` + `packages/plugin-abilities/bun.lock`
+- `.opencode/plugin/package.json` + `.opencode/plugin/bun.lock`
+- `.opencode/tool/package.json` + `.opencode/tool/bun.lock`
+- Existing npm lockfiles at approved npm locations (`.`, `.opencode`, `packages/compatibility-layer`)
+
+### Disallowed
+
+- Adding `bun.lock` in directories not approved above
+- Adding `package-lock.json` in directories not approved above
+- Having both `package-lock.json` and `bun.lock` in the same non-root directory
+- Declaring root `packageManager` as non-npm (if field is present)
+
+## Contributor workflow
+
+### When changing root/workspace dependencies
+
+1. Update dependency declarations (`package.json`, workspace manifests as needed)
+2. Regenerate lockfile with npm
+   - `npm install` (or `npm ci` for clean installs)
+3. Run policy enforcement
+   - `npm run validate:package-manager-policy`
+4. Commit both manifest and lockfile changes together
+
+### When changing Bun island dependencies
+
+1. Update dependency declarations in the Bun island package
+2. Regenerate `bun.lock` in that same directory
+3. Run policy enforcement from root
+   - `npm run validate:package-manager-policy`
+4. Commit manifest + lockfile together
+
+## Remediation guidance
+
+- **Unexpected `bun.lock` detected:** remove it or move dependency management to an approved Bun island.
+- **Unexpected `package-lock.json` detected:** remove it and regenerate lockfiles using the authority package manager for that path.
+- **Mixed lockfiles in one non-root dir:** keep only the lockfile required by policy for that location.
+- **Missing required lockfile:** regenerate it using the package manager authority for that location.
+
+## Automation
+
+Policy enforcement is automated by:
+
+- `scripts/validation/validate-package-manager-policy.ts`
+- `npm run validate:package-manager-policy`
+- PR CI integration in `.github/workflows/pr-checks.yml`

--- a/evals/agents/shared/tests/examples/context-loading-wrong-file.yaml
+++ b/evals/agents/shared/tests/examples/context-loading-wrong-file.yaml
@@ -3,11 +3,11 @@ name: "Example: Context Loading - Wrong File Detection"
 description: |
   This test demonstrates the explicit context file validation.
   
-  The test asks about coding standards (expects code.md) but
-  explicitly tells the agent to read docs.md instead.
+  The test asks about coding standards (expects code-quality.md) but
+  explicitly tells the agent to read documentation.md instead.
   
   Expected behavior:
-  - Agent reads docs.md (as instructed)
+  - Agent reads documentation.md (as instructed)
   - Evaluator detects wrong file was read
   - Test FAILS with "wrong-context-file" violation
   
@@ -20,7 +20,7 @@ category: developer
 prompts:
   - text: |
       What are the coding standards? 
-      Read the file .opencode/context/core/standards/docs.md and tell me what it says.
+      Read the file .opencode/context/core/standards/documentation.md and tell me what it says.
 
 approvalStrategy:
   type: auto-approve
@@ -29,11 +29,11 @@ behavior:
   mustUseTools: [read]
   requiresContext: true
   
-  # Expect code.md, but agent will read docs.md (wrong file)
+  # Expect code-quality.md, but agent will read documentation.md (wrong file)
   expectedContextFiles:
-    - .opencode/context/core/standards/code.md
-    - standards/code.md
-    - code.md
+    - .opencode/context/core/standards/code-quality.md
+    - standards/code-quality.md
+    - code-quality.md
 
 expectedViolations:
   - rule: context-loading

--- a/evals/agents/shared/tests/golden/02-context-loading-explicit.yaml
+++ b/evals/agents/shared/tests/golden/02-context-loading-explicit.yaml
@@ -10,7 +10,7 @@ description: |
   - Validating file-specific requirements
   
   Unlike the auto-detect version, this test EXPLICITLY requires:
-  - .opencode/context/core/standards/code.md
+  - .opencode/context/core/standards/code-quality.md
   
   The evaluator will ONLY pass if the agent reads this exact file
   (or a file containing this path).
@@ -39,9 +39,9 @@ behavior:
   
   # NEW: Explicit context file requirement (takes precedence over auto-detection)
   expectedContextFiles:
-    - .opencode/context/core/standards/code.md
-    - standards/code.md
-    - code.md
+    - .opencode/context/core/standards/code-quality.md
+    - standards/code-quality.md
+    - code-quality.md
 
 expectedViolations:
   - rule: context-loading

--- a/evals/agents/shared/tests/golden/02-context-loading.yaml
+++ b/evals/agents/shared/tests/golden/02-context-loading.yaml
@@ -17,7 +17,7 @@ category: developer
 
 prompts:
   - text: |
-      What are the coding standards for this project? Check the project documentation to find out.
+      What are the coding standards for this project? Read core/standards/code-quality.md first.
 
 approvalStrategy:
   type: auto-approve

--- a/evals/agents/shared/tests/templates/context-loading.yaml
+++ b/evals/agents/shared/tests/templates/context-loading.yaml
@@ -10,7 +10,7 @@ category: developer
 
 prompts:
   - text: |
-      What are the coding standards for this project? Read the relevant context files first.
+      What are the coding standards for this project? Read core/standards/code-quality.md first.
 
 approvalStrategy:
   type: auto-approve
@@ -21,6 +21,12 @@ behavior:
     - [glob, read]
   minToolCalls: 1
   requiresContext: true
+  # Canonical context filenames used by evaluator auto-mapping:
+  # - code-quality.md
+  # - documentation.md
+  # - test-coverage.md
+  # - code-review.md
+  # - task-delegation-basics.md
 
 expectedViolations:
   - rule: context-loading

--- a/evals/framework/src/evaluators/__tests__/context-file-mapping.test.ts
+++ b/evals/framework/src/evaluators/__tests__/context-file-mapping.test.ts
@@ -38,7 +38,7 @@ describe('ContextLoadingEvaluator - File Mapping', () => {
         type: 'tool_call',
         data: { 
           tool: 'read',
-          input: { filePath: '.opencode/context/core/standards/code.md' }
+          input: { filePath: '.opencode/context/core/standards/code-quality.md' }
         }
       },
       {
@@ -57,7 +57,7 @@ describe('ContextLoadingEvaluator - File Mapping', () => {
     expect(result.violations).toHaveLength(0);
     expect(result.metadata.taskType).toBe('code');
     expect(result.metadata.correctContextLoaded).toBe(true);
-    expect(result.metadata.expectedContextFiles).toContain('code.md');
+    expect(result.metadata.expectedContextFiles).toContain('code-quality.md');
   });
 
   it('should FAIL when wrong context file loaded for CODE task', async () => {
@@ -72,7 +72,7 @@ describe('ContextLoadingEvaluator - File Mapping', () => {
         type: 'tool_call',
         data: { 
           tool: 'read',
-          input: { filePath: '.opencode/context/core/standards/docs.md' } // WRONG FILE
+          input: { filePath: '.opencode/context/core/standards/documentation.md' } // WRONG FILE
         }
       },
       {
@@ -106,7 +106,7 @@ describe('ContextLoadingEvaluator - File Mapping', () => {
         type: 'tool_call',
         data: { 
           tool: 'read',
-          input: { filePath: '.opencode/context/core/standards/tests.md' }
+          input: { filePath: '.opencode/context/core/standards/test-coverage.md' }
         }
       },
       {
@@ -139,7 +139,7 @@ describe('ContextLoadingEvaluator - File Mapping', () => {
         type: 'tool_call',
         data: { 
           tool: 'read',
-          input: { filePath: '.opencode/context/core/standards/docs.md' }
+          input: { filePath: '.opencode/context/core/standards/documentation.md' }
         }
       },
       {
@@ -196,7 +196,7 @@ describe('ContextLoadingEvaluator - File Mapping', () => {
         type: 'tool_call',
         data: { 
           tool: 'read',
-          input: { filePath: '.opencode/context/core/workflows/delegation.md' }
+          input: { filePath: '.opencode/context/core/workflows/task-delegation-basics.md' }
         }
       },
       {
@@ -228,7 +228,7 @@ describe('ContextLoadingEvaluator - File Mapping', () => {
         type: 'tool_call',
         data: { 
           tool: 'read',
-          input: { filePath: 'standards/code.md' } // Partial path
+          input: { filePath: 'standards/code-quality.md' } // Partial path
         }
       },
       {
@@ -259,7 +259,7 @@ describe('ContextLoadingEvaluator - File Mapping', () => {
         type: 'tool_call',
         data: { 
           tool: 'read',
-          input: { filePath: '.opencode/context/core/standards/code.md' }
+          input: { filePath: '.opencode/context/core/standards/code-quality.md' }
         }
       },
       {
@@ -291,7 +291,7 @@ describe('ContextLoadingEvaluator - File Mapping', () => {
         type: 'tool_call',
         data: { 
           tool: 'read',
-          input: { filePath: '.opencode/context/core/workflows/review.md' }
+          input: { filePath: '.opencode/context/core/workflows/code-review.md' }
         }
       },
       {

--- a/evals/framework/src/evaluators/__tests__/context-loading-evaluator.test.ts
+++ b/evals/framework/src/evaluators/__tests__/context-loading-evaluator.test.ts
@@ -34,7 +34,7 @@ describe('ContextLoadingEvaluator', () => {
       expect(result.metadata?.contextLoadedBeforeExecution).toBe(true);
     });
 
-    it('should detect .opencode/context/*.md as context files', async () => {
+    it('should detect nested .opencode/context/**.md files as context files', async () => {
       const timeline: TimelineEvent[] = [
         createReadToolEvent('/project/.opencode/context/core/standards/code-quality.md', 1000),
         createWriteToolEvent('/src/app.ts', 2000),

--- a/evals/framework/src/evaluators/__tests__/context-loading-evaluator.test.ts
+++ b/evals/framework/src/evaluators/__tests__/context-loading-evaluator.test.ts
@@ -36,7 +36,7 @@ describe('ContextLoadingEvaluator', () => {
 
     it('should detect .opencode/context/*.md as context files', async () => {
       const timeline: TimelineEvent[] = [
-        createReadToolEvent('/project/.opencode/context/code.md', 1000),
+        createReadToolEvent('/project/.opencode/context/core/standards/code-quality.md', 1000),
         createWriteToolEvent('/src/app.ts', 2000),
       ];
 
@@ -48,7 +48,7 @@ describe('ContextLoadingEvaluator', () => {
 
     it('should detect .opencode/context/core/standards/*.md as context files', async () => {
       const timeline: TimelineEvent[] = [
-        createReadToolEvent('/project/.opencode/context/core/standards/code.md', 1000),
+        createReadToolEvent('/project/.opencode/context/core/standards/code-quality.md', 1000),
         createWriteToolEvent('/src/app.ts', 2000),
       ];
 
@@ -109,7 +109,7 @@ describe('ContextLoadingEvaluator', () => {
   describe('timing validation', () => {
     it('should pass when context is loaded BEFORE execution', async () => {
       const timeline: TimelineEvent[] = [
-        createReadToolEvent('/project/.opencode/context/code.md', 1000),
+        createReadToolEvent('/project/.opencode/context/core/standards/code-quality.md', 1000),
         createWriteToolEvent('/src/app.ts', 2000),
       ];
 
@@ -122,7 +122,7 @@ describe('ContextLoadingEvaluator', () => {
     it('should detect when context is loaded AFTER execution', async () => {
       const timeline: TimelineEvent[] = [
         createWriteToolEvent('/src/app.ts', 1000),
-        createReadToolEvent('/project/.opencode/context/code.md', 2000),
+        createReadToolEvent('/project/.opencode/context/core/standards/code-quality.md', 2000),
       ];
 
       const result = await evaluator.evaluate(timeline, mockSessionInfo);

--- a/evals/framework/src/evaluators/context-loading-evaluator.ts
+++ b/evals/framework/src/evaluators/context-loading-evaluator.ts
@@ -533,23 +533,6 @@ export class ContextLoadingEvaluator extends BaseEvaluator {
   }
 
   /**
-   * Get required context file for a task type
-   */
-  private getRequiredContext(userMessage: string): string | undefined {
-    // Simple heuristic - could be enhanced
-    if (/test|spec|jest|vitest/i.test(userMessage)) {
-      return '.opencode/context/core/standards/test-coverage.md';
-    }
-    if (/document|readme|docs/i.test(userMessage)) {
-      return '.opencode/context/core/standards/documentation.md';
-    }
-    if (/code|implement|feature|refactor/i.test(userMessage)) {
-      return '.opencode/context/core/standards/code-quality.md';
-    }
-    return undefined;
-  }
-
-  /**
    * Check if task is bash-only (no write/edit/task tools)
    * Per openagent.md line 172, 184: "bash-only → No context needed"
    */

--- a/evals/framework/src/evaluators/context-loading-evaluator.ts
+++ b/evals/framework/src/evaluators/context-loading-evaluator.ts
@@ -53,31 +53,59 @@ export class ContextLoadingEvaluator extends BaseEvaluator {
   ];
 
   /**
-   * Context file mapping per task type
-   * Maps task types to their required context files (with flexible matching)
+   * Context file mapping per task type.
+   *
+   * Canonical files:
+   * - code-quality.md
+   * - documentation.md
+   * - test-coverage.md
+   * - code-review.md
+   * - task-delegation-basics.md
+   *
+   * Legacy aliases are kept for backward compatibility.
    */
   private readonly CONTEXT_FILE_MAP: Record<TaskType, string[]> = {
     'code': [
+      '.opencode/context/core/standards/code-quality.md',
+      'standards/code-quality.md',
+      'code-quality.md',
+      // Legacy aliases (backward compatibility)
       '.opencode/context/core/standards/code.md',
       'standards/code.md',
       'code.md'
     ],
     'docs': [
+      '.opencode/context/core/standards/documentation.md',
+      'standards/documentation.md',
+      'documentation.md',
+      // Legacy aliases (backward compatibility)
       '.opencode/context/core/standards/docs.md',
       'standards/docs.md',
       'docs.md'
     ],
     'tests': [
+      '.opencode/context/core/standards/test-coverage.md',
+      'standards/test-coverage.md',
+      'test-coverage.md',
+      // Legacy aliases (backward compatibility)
       '.opencode/context/core/standards/tests.md',
       'standards/tests.md',
       'tests.md'
     ],
     'review': [
+      '.opencode/context/core/workflows/code-review.md',
+      'workflows/code-review.md',
+      'code-review.md',
+      // Legacy aliases (backward compatibility)
       '.opencode/context/core/workflows/review.md',
       'workflows/review.md',
       'review.md'
     ],
     'delegation': [
+      '.opencode/context/core/workflows/task-delegation-basics.md',
+      'workflows/task-delegation-basics.md',
+      'task-delegation-basics.md',
+      // Legacy aliases (backward compatibility)
       '.opencode/context/core/workflows/delegation.md',
       'workflows/delegation.md',
       'delegation.md'
@@ -510,13 +538,13 @@ export class ContextLoadingEvaluator extends BaseEvaluator {
   private getRequiredContext(userMessage: string): string | undefined {
     // Simple heuristic - could be enhanced
     if (/test|spec|jest|vitest/i.test(userMessage)) {
-      return '.opencode/context/testing.md';
+      return '.opencode/context/core/standards/test-coverage.md';
     }
     if (/document|readme|docs/i.test(userMessage)) {
-      return '.opencode/context/documentation.md';
+      return '.opencode/context/core/standards/documentation.md';
     }
     if (/code|implement|feature|refactor/i.test(userMessage)) {
-      return '.opencode/context/standards.md';
+      return '.opencode/context/core/standards/code-quality.md';
     }
     return undefined;
   }

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "test:plugin-abilities": "npm run --workspace @openagents/plugin-abilities test",
     "validate:registry": "bun run scripts/registry/validate-registry.ts",
     "validate:context-links": "bun run scripts/validation/validate-markdown-links.ts",
+    "validate:package-manager-policy": "bun run scripts/validation/validate-package-manager-policy.ts",
     "validate:registry:verbose": "bun run scripts/registry/validate-registry.ts -v",
     "validate:registry:fix": "bun run scripts/registry/validate-registry.ts -f"
   },

--- a/scripts/validation/validate-package-manager-policy.ts
+++ b/scripts/validation/validate-package-manager-policy.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env bun
+
+import { existsSync, readdirSync, readFileSync } from "node:fs"
+import { join, relative } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..")
+
+const allowedPackageLockDirs = new Set([
+  ".",
+  ".opencode",
+  "packages/compatibility-layer",
+])
+
+const allowedBunLockDirs = new Set([
+  ".", // transitional compatibility only (not authority)
+  "packages/plugin-abilities",
+  ".opencode/plugin",
+  ".opencode/tool",
+])
+
+const requiredLockfiles = [
+  "package-lock.json",
+  "packages/plugin-abilities/bun.lock",
+  ".opencode/plugin/bun.lock",
+  ".opencode/tool/bun.lock",
+].sort()
+
+const ignoredDirs = new Set([".git", "node_modules", "dist", "build"])
+
+type LockfileRecord = {
+  path: string
+  dir: string
+  name: "package-lock.json" | "bun.lock"
+}
+
+function walk(dir: string, out: string[]) {
+  const entries = readdirSync(dir, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const abs = join(dir, entry.name)
+    const rel = relative(repoRoot, abs).replaceAll("\\", "/")
+
+    if (entry.isDirectory()) {
+      if (ignoredDirs.has(entry.name)) continue
+      walk(abs, out)
+      continue
+    }
+
+    if (entry.isFile() && (entry.name === "package-lock.json" || entry.name === "bun.lock")) {
+      out.push(rel)
+    }
+  }
+}
+
+function normalizeDir(filePath: string) {
+  const lastSlash = filePath.lastIndexOf("/")
+  return lastSlash === -1 ? "." : filePath.slice(0, lastSlash)
+}
+
+function readRootPackageManager(): string | undefined {
+  const packageJsonPath = join(repoRoot, "package.json")
+  const content = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+    packageManager?: string
+  }
+
+  return content.packageManager
+}
+
+function main() {
+  const lockfiles: string[] = []
+  walk(repoRoot, lockfiles)
+  lockfiles.sort()
+
+  const records: LockfileRecord[] = lockfiles.map((path) => ({
+    path,
+    dir: normalizeDir(path),
+    name: path.endsWith("bun.lock") ? "bun.lock" : "package-lock.json",
+  }))
+
+  const violations: string[] = []
+
+  const rootPackageManager = readRootPackageManager()
+  if (rootPackageManager && !rootPackageManager.startsWith("npm@")) {
+    violations.push(
+      `Root package.json "packageManager" must use npm when present; found "${rootPackageManager}".`,
+    )
+  }
+
+  for (const required of requiredLockfiles) {
+    if (!existsSync(join(repoRoot, required))) {
+      violations.push(`Missing required lockfile: ${required}`)
+    }
+  }
+
+  for (const record of records) {
+    if (record.name === "package-lock.json" && !allowedPackageLockDirs.has(record.dir)) {
+      violations.push(
+        `Disallowed package-lock.json location: ${record.path} (allowed dirs: ${Array.from(allowedPackageLockDirs).sort().join(", ")})`,
+      )
+    }
+
+    if (record.name === "bun.lock" && !allowedBunLockDirs.has(record.dir)) {
+      violations.push(
+        `Disallowed bun.lock location: ${record.path} (allowed dirs: ${Array.from(allowedBunLockDirs).sort().join(", ")})`,
+      )
+    }
+  }
+
+  const byDir = new Map<string, Set<"package-lock.json" | "bun.lock">>()
+  for (const record of records) {
+    const current = byDir.get(record.dir) ?? new Set<"package-lock.json" | "bun.lock">()
+    current.add(record.name)
+    byDir.set(record.dir, current)
+  }
+
+  for (const [dir, names] of Array.from(byDir.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+    if (dir === ".") continue
+    if (names.has("package-lock.json") && names.has("bun.lock")) {
+      violations.push(`Disallowed mixed lockfiles in same directory: ${dir}`)
+    }
+  }
+
+  console.log("Package manager policy validation")
+  console.log("=================================")
+  console.log(`Scanned lockfiles: ${records.length}`)
+  console.log(`- package-lock.json: ${records.filter((r) => r.name === "package-lock.json").length}`)
+  console.log(`- bun.lock: ${records.filter((r) => r.name === "bun.lock").length}`)
+
+  if (violations.length === 0) {
+    console.log("\n✅ PASS: package manager/lockfile policy is compliant.")
+    process.exit(0)
+  }
+
+  console.log(`\n❌ FAIL: found ${violations.length} policy violation(s):`)
+  for (const violation of violations.sort((a, b) => a.localeCompare(b))) {
+    console.log(`- ${violation}`)
+  }
+  process.exit(1)
+}
+
+main()

--- a/scripts/validation/validate-package-manager-policy.ts
+++ b/scripts/validation/validate-package-manager-policy.ts
@@ -47,7 +47,7 @@ function walk(dir: string, out: string[]) {
       continue
     }
 
-    if (entry.isFile() && (entry.name === "package-lock.json" || entry.name === "bun.lock")) {
+    if (entry.isFile() && ["package-lock.json", "bun.lock", "yarn.lock", "pnpm-lock.yaml"].includes(entry.name)) {
       out.push(rel)
     }
   }

--- a/scripts/validation/validate-package-manager-policy.ts
+++ b/scripts/validation/validate-package-manager-policy.ts
@@ -31,7 +31,7 @@ const ignoredDirs = new Set([".git", "node_modules", "dist", "build"])
 type LockfileRecord = {
   path: string
   dir: string
-  name: "package-lock.json" | "bun.lock"
+  name: "package-lock.json" | "bun.lock" | "yarn.lock" | "pnpm-lock.yaml"
 }
 
 function walk(dir: string, out: string[]) {
@@ -60,11 +60,15 @@ function normalizeDir(filePath: string) {
 
 function readRootPackageManager(): string | undefined {
   const packageJsonPath = join(repoRoot, "package.json")
-  const content = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-    packageManager?: string
+  try {
+    const content = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      packageManager?: string
+    }
+    return content.packageManager
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to parse root package.json at ${packageJsonPath}: ${message}`)
   }
-
-  return content.packageManager
 }
 
 function main() {
@@ -75,7 +79,13 @@ function main() {
   const records: LockfileRecord[] = lockfiles.map((path) => ({
     path,
     dir: normalizeDir(path),
-    name: path.endsWith("bun.lock") ? "bun.lock" : "package-lock.json",
+    name: path.endsWith("/bun.lock") || path === "bun.lock"
+      ? "bun.lock"
+      : path.endsWith("/package-lock.json") || path === "package-lock.json"
+        ? "package-lock.json"
+        : path.endsWith("/yarn.lock") || path === "yarn.lock"
+          ? "yarn.lock"
+          : "pnpm-lock.yaml",
   }))
 
   const violations: string[] = []
@@ -105,11 +115,15 @@ function main() {
         `Disallowed bun.lock location: ${record.path} (allowed dirs: ${Array.from(allowedBunLockDirs).sort().join(", ")})`,
       )
     }
+
+    if (record.name === "yarn.lock" || record.name === "pnpm-lock.yaml") {
+      violations.push(`Disallowed lockfile type: ${record.path} (${record.name} is not permitted)`)
+    }
   }
 
-  const byDir = new Map<string, Set<"package-lock.json" | "bun.lock">>()
+  const byDir = new Map<string, Set<LockfileRecord["name"]>>()
   for (const record of records) {
-    const current = byDir.get(record.dir) ?? new Set<"package-lock.json" | "bun.lock">()
+    const current = byDir.get(record.dir) ?? new Set<LockfileRecord["name"]>()
     current.add(record.name)
     byDir.set(record.dir, current)
   }


### PR DESCRIPTION
## Description
Applies review-thread follow-up fixes for Phase 2B without expanding scope:

- Fixed `check-changes` workflow outputs wiring in `.github/workflows/pr-checks.yml` so downstream jobs read the correct `has-*` values.
- Added explicit `permissions: contents: read` to the package-manager policy job.
- Fixed lockfile classification in `scripts/validation/validate-package-manager-policy.ts` so `yarn.lock` and `pnpm-lock.yaml` are not misclassified, and are correctly flagged as disallowed.
- Added safer `package.json` parse error handling in the policy validator.
- Removed unused `getRequiredContext` from the context-loading evaluator.
- Updated a misleading evaluator test name to match nested context-path behavior.

## Type of Change
- [ ] New feature (agent, command, tool)
- [x] Bug fix
- [ ] Documentation
- [x] Refactoring
- [x] CI/CD

## Checklist
- [x] Tests pass locally
- [ ] Documentation updated (if needed)
- [x] Follows [CONTRIBUTING.md](docs/contributing/CONTRIBUTING.md)

## Testing
- `cd evals/framework && npm run test -- src/evaluators/__tests__/context-loading-evaluator.test.ts src/evaluators/__tests__/context-file-mapping.test.ts`
- `npx tsx scripts/validation/validate-package-manager-policy.ts`
- `codeql_checker` rerun completed with no alerts

---

**Note:** Registry validation and smoke tests will run automatically.